### PR TITLE
uk-production support

### DIFF
--- a/almdrlib/apis/credentials/credentials.v2.yaml
+++ b/almdrlib/apis/credentials/credentials.v2.yaml
@@ -6,7 +6,10 @@ info:
     name: MIT License
 servers:
   - url: 'https://api.cloudinsight.alertlogic.com'
-    description: production
+    description: us-production
+    x-alertlogic-session-endpoint: true
+  - url: 'https://api.cloudinsight.alertlogic.co.uk'
+    description: uk-production
     x-alertlogic-session-endpoint: true
   - url: 'https://api.cloudinsight.product.dev.alertlogic.com'
     description: integration

--- a/almdrlib/apis/deployments/deployments.v1.yaml
+++ b/almdrlib/apis/deployments/deployments.v1.yaml
@@ -8,7 +8,10 @@ info:
     name: Alert Logic Support
 servers:
   - url: 'https://api.cloudinsight.alertlogic.com'
-    description: production
+    description: us-production
+    x-alertlogic-session-endpoint: true
+  - url: 'https://api.cloudinsight.alertlogic.co.uk'
+    description: uk-production
     x-alertlogic-session-endpoint: true
   - url: 'https://api.cloudinsight.product.dev.alertlogic.com'
     description: integration

--- a/almdrlib/apis/policies/policies.v1.yaml
+++ b/almdrlib/apis/policies/policies.v1.yaml
@@ -4,7 +4,10 @@ info:
   version: '1.0'
 servers:
   - url: 'https://api.cloudinsight.alertlogic.com'
-    description: production
+    description: us-production
+    x-alertlogic-session-endpoint: true
+  - url: 'https://api.cloudinsight.alertlogic.co.uk'
+    description: uk-production
     x-alertlogic-session-endpoint: true
   - url: 'https://api.cloudinsight.product.dev.alertlogic.com'
     description: integration

--- a/almdrlib/apis/themis/themis.v1.yaml
+++ b/almdrlib/apis/themis/themis.v1.yaml
@@ -6,7 +6,10 @@ info:
     Alert Logic MDR External Permissions Management Service
 servers:
   - url: 'https://api.cloudinsight.alertlogic.com'
-    description: production
+    description: us-production
+    x-alertlogic-session-endpoint: true
+  - url: 'https://api.cloudinsight.alertlogic.co.uk'
+    description: uk-production
     x-alertlogic-session-endpoint: true
   - url: 'https://api.cloudinsight.product.dev.alertlogic.com'
     description: integration


### PR DESCRIPTION
Updated "region" sensitive services with `uk-production` servers. BREXIT has been commenced but we don't want to discriminate against the United Kingdom, do we?

The remaining question is shouldn't we unify `servers` naming to distinguish the global services stack?

