### PR TITLE
Support further query parameter serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+almdrlib/version.py
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -128,4 +129,6 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+# IntelliJ
 *.iml
+.idea

--- a/almdrlib/config.py
+++ b/almdrlib/config.py
@@ -54,7 +54,7 @@ class Config():
             self._config_file = almdrlib.constants.DEFAULT_CONFIG_FILE
 
         logger.debug(
-                f"Initializing configuration using " +
+                "Initializing configuration using " +
                 f"'{self._config_file}' configuration file")
         if access_key_id or secret_key:
             self._access_key_id = access_key_id
@@ -86,7 +86,7 @@ class Config():
         else:
             self._initialize_defaults()
 
-        logger.debug(f"Finished configuraiton initialization. " +
+        logger.debug("Finished configuraiton initialization. " +
                      f"access_key_id={self._access_key_id}, " +
                      f"account_id={self._account_id}, " +
                      f"global_endpoint={self._global_endpoint}")

--- a/tests/apis/testapi/testapi.v1.yaml
+++ b/tests/apis/testapi/testapi.v1.yaml
@@ -50,8 +50,13 @@ paths:
         - schema:
             type: array
           in: query
-          name: query_param1
-          description: 'query parameter 1 description: optional; array'
+          name: query_param2
+          description: 'query parameter 2 description: optional; array'
+        - schema:
+            type: object
+          in: query
+          name: query_param3
+          description: 'query parameter 3 description: optional; object; exploded'
       responses:
         '200':
           description: OK

--- a/tests/data/test_open_api_support.json
+++ b/tests/data/test_open_api_support.json
@@ -36,9 +36,20 @@
 					"description": "header parameter 2 description - integer"
 				},
 				"query_param1": {
+					"type": "string",
+					"in": "query",
+					"description": "query parameter 1 description: required; string",
+					"required": true
+				},
+				"query_param2": {
 					"type": "array",
 					"in": "query",
-					"description": "query parameter 1 description: optional; array"
+					"description": "query parameter 2 description: optional; array"
+				},
+				"query_param3": {
+					"type": "object",
+					"in": "query",
+					"description": "query parameter 3 description: optional; object; exploded"
 				}
 			}
 		},

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ python =
 [testenv:flake8]
 basepython = python
 deps = flake8
-commands = flake8 alertlogic-sdk-python
+commands = flake8 almdrlib
 
 [testenv]
 setenv =


### PR DESCRIPTION
* Add support for serializing a subset of OpenAPI Parameter query parameter styles in combination with explode boolean: form, spaceDelimited, pipeDelimited
* Fix flake8 command in tox.ini (test code in almdrlib folder)
* Fix flake8 warnings in config.py
* Add object query parameter to test OpenAPI spec
* gitignore updates: ignore almdrlib/version.py, ignore IntelliJ .idea folder, clarify *.iml are related to IntelliJ