### PR TITLE
Move parsing, loading and normalisation logic for the definitions to …

### DIFF
--- a/almdrlib/config.py
+++ b/almdrlib/config.py
@@ -5,7 +5,6 @@ import configparser
 import logging
 import almdrlib.constants
 from almdrlib.exceptions import AlmdrlibValueError
-import alsdkdefs
 
 logger = logging.getLogger(__name__)
 
@@ -205,7 +204,7 @@ class Config():
     @staticmethod
     def get_api_dir():
         api_dir = os.environ.get('ALERTLOGIC_API')
-        return api_dir and f"{api_dir}" or alsdkdefs.get_apis_dir()
+        return api_dir and f"{api_dir}"
 
 
 def _get_config_parser(config_file=almdrlib.constants.DEFAULT_CONFIG_FILE):

--- a/almdrlib/docs/service.py
+++ b/almdrlib/docs/service.py
@@ -7,7 +7,7 @@ except Exception:
     def convert(text):
         return text
 
-from almdrlib.client import OpenAPIKeyWord
+from alsdkdefs import OpenAPIKeyWord
 
 logger = logging.getLogger(__name__)
 

--- a/almdrlib/session.py
+++ b/almdrlib/session.py
@@ -16,6 +16,7 @@ from requests.packages.urllib3.util.retry import Retry
 from almdrlib.config import Config
 from almdrlib.region import Region
 from almdrlib.client import Client
+import alsdkdefs
 
 logger = logging.getLogger(__name__)
 
@@ -299,7 +300,7 @@ class Session():
 
     @staticmethod
     def list_services():
-        return sorted(next(os.walk(Config.get_api_dir()))[1])
+        return alsdkdefs.list_services()
 
     @staticmethod
     def get_service_api(service_name, version=None):

--- a/tests/test_open_api_support.py
+++ b/tests/test_open_api_support.py
@@ -9,7 +9,7 @@ import unittest
 from almdrlib.session import Session
 from almdrlib.client import Client
 from almdrlib.client import Operation
-from almdrlib.client import OpenAPIKeyWord
+from alsdkdefs import OpenAPIKeyWord
 
 
 class TestSdk_open_api_support(unittest.TestCase):
@@ -33,8 +33,6 @@ class TestSdk_open_api_support(unittest.TestCase):
 
     def test_000_getting_schemas(self):
         """Test listing services."""
-        services = Session.list_services()
-        self.assertTrue(self._service_name in services)
         self.assertTrue(len(Session.get_service_api("testapi")))
         print(f"SCHEMA: {json.dumps(Session.get_service_api('testapi'))}")
 
@@ -66,7 +64,7 @@ class TestSdk_open_api_support(unittest.TestCase):
             self.assertIsNot(schema, {})
 
             t_operation_parameters = t_operation_schema[
-                                        OpenAPIKeyWord.PARAMETERS]
+                OpenAPIKeyWord.PARAMETERS]
 
             operation_parameters = schema[OpenAPIKeyWord.PARAMETERS]
             for name, value in t_operation_parameters.items():
@@ -74,7 +72,7 @@ class TestSdk_open_api_support(unittest.TestCase):
 
             if OpenAPIKeyWord.CONTENT in t_operation_schema:
                 t_operation_content = t_operation_schema[
-                                            OpenAPIKeyWord.CONTENT]
+                    OpenAPIKeyWord.CONTENT]
                 operation_content = schema[OpenAPIKeyWord.CONTENT]
                 for name, value in t_operation_content.items():
                     self.assertEqual(value, operation_content[name])


### PR DESCRIPTION
### Problem
Parsing and normalisation logic is too coupled with client initialisation logic
Hard to test definitions to be compatible with sdk since loading logic is in the library

### 
Move parsing, loading and normalisation logic for the definitions to the alsdkdefs package
Add common validation point