### PR TITLE
Local services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,9 @@ target/
 profile_default/
 ipython_config.py
 
+#IntelliJ
+.idea
+
 # pyenv
 .python-version
 

--- a/README.md
+++ b/README.md
@@ -79,3 +79,28 @@ pip install -r requirements_dev.txt
 pip install -e .
 ```
     
+### Using local services
+
+- Setup a local profile:
+
+```
+[aesolo]
+access_key_id=skip
+secret_key=skip
+global_endpoint=map
+endpoint_map_file=aesolo.json
+```
+
+- Write an endpoint map (here, `~/.alertlogic/aesolo.json`; `endpoint_map_file` can also be an absolute path):
+
+```
+{
+  "aecontent" : "http://127.0.0.1:8810",
+  "aefr" : "http://127.0.0.1:8808",
+  "aepublish" : "http://127.0.0.1:8811",
+  "aerta" : "http://127.0.0.1:8809",
+  "aetag" : "http://127.0.0.1:8812",
+  "aetuner": "http://127.0.0.1:3000",
+  "ingest" : "http://127.0.0.1:9000"
+}
+```

--- a/almdrlib/constants.py
+++ b/almdrlib/constants.py
@@ -7,4 +7,5 @@ DEFAULT_CONFIG_FILE = os.path.join(DEFAULT_CONFIG_DIR, "config")
 DEFAULT_CREDENTIALS_FILE = os.path.join(DEFAULT_CONFIG_DIR, "credentials")
 DEFAULT_PROFILE = "default"
 DEFAULT_GLOBAL_ENDPOINT = "production"
+DEFAULT_ENDPOINT_MAP_FILE = "endpoint_map.json"
 DEFAULT_RESIDENCY = "default"

--- a/almdrlib/session.py
+++ b/almdrlib/session.py
@@ -58,7 +58,7 @@ class Session():
                             the account id of the access_key_id is used.
         :param: profile: name of the profile section of the configuration file
         :param: global_endpoint: Name of the global endpoint.
-                                 'production' or 'integration' are
+                                 'production', 'integration', or 'map' are
                                  the only valid values
         :param residency: Data residency name to perform
                           data residency dependend actions.
@@ -118,6 +118,7 @@ class Session():
         self._account_id = self._config.account_id
         self._residency = self._config.residency
         self._global_endpoint = self._config.global_endpoint
+        self._endpoint_map = self._config.endpoint_map
         self._global_endpoint_url = Region.get_global_endpoint(
                                                         self._global_endpoint)
         self._raise_for_status = kwargs.get('raise_for_status')
@@ -142,6 +143,14 @@ class Session():
         """
 
         if not self._token:
+            if self._access_key_id == "skip" and self._secret_key == "skip":
+                logger.info(
+                        f"Skipping authentication."
+                    )
+                self._token = ""
+                self._account_id = ""
+                self._account_name = ""
+                return
             logger.info(
                     f"Authenticating '{self._access_key_id}' " +
                     f"user against '{self._global_endpoint_url}' endpoint."
@@ -235,6 +244,8 @@ class Session():
         return _client
 
     def get_url(self, service_name, account_id=None):
+        if self._global_endpoint == "map":
+            return self.get_mapped_url(service_name, account_id)
         try:
             response = self.request(
                 'get',
@@ -249,6 +260,10 @@ class Session():
                     f"invalid http response from endpoints service {e}"
                 )
         return "https://{}".format(response.json()[service_name])
+
+    def get_mapped_url(self, service_name, account_id):
+        map = self._endpoint_map
+        return map[service_name]
 
     def request(
             self,


### PR DESCRIPTION
Problem to solve:

- Need a way to test API specs against al services running locally during development
- Need a way to troubleshoot services running locally exercised by applications using the alertlogic python sdk.

Proposed solution:

- global endpoint "map" using a json file specified by the config value `endpoint_map_file`
