### PR TITLE
Initialise _endpoints_map in the client since it is requested by default session

### DIFF
--- a/almdrlib/config.py
+++ b/almdrlib/config.py
@@ -53,6 +53,7 @@ class Config():
                  endpoint_map_file=None,
                  residency=None):
         self._config_file = os.environ.get('ALERTLOGIC_CONFIG')
+        self._endpoint_map = None
         if self._config_file is None:
             self._config_file = almdrlib.constants.DEFAULT_CONFIG_FILE
 

--- a/tests/test_open_api_support.py
+++ b/tests/test_open_api_support.py
@@ -8,7 +8,9 @@ import unittest
 
 from almdrlib.session import Session
 from almdrlib.client import Client
+from almdrlib.client import Config
 from almdrlib.client import Operation
+import almdrlib
 from alsdkdefs import OpenAPIKeyWord
 
 
@@ -76,3 +78,9 @@ class TestSdk_open_api_support(unittest.TestCase):
                 operation_content = schema[OpenAPIKeyWord.CONTENT]
                 for name, value in t_operation_content.items():
                     self.assertEqual(value, operation_content[name])
+
+    def test_003_default_objects_creation(self):
+        """Checks initialisation at least happens"""
+        self.assertIsInstance(almdrlib.Session(), Session)
+        self.assertIsInstance(almdrlib.Config(), Config)
+        self.assertIsInstance(Client(self._service_name), Client)


### PR DESCRIPTION
Modify tests to invoke session so such cases are caught