### PR TITLE
Don't log AIMS tokens

### DIFF
--- a/almdrlib/client.py
+++ b/almdrlib/client.py
@@ -634,7 +634,7 @@ class Client(object):
 
     def load_service_spec(self, service_name, version=None, variables=None):
         logger.debug(
-            f"Initializing client for '{self._name}'" +
+            f"Initializing client for '{self._name}' " +
             f"Spec: '{service_name}' Variables: '{variables}'")
         spec = alsdkdefs.load_service_spec(service_name, Config.get_api_dir(), version)
         self.load_spec(spec, variables)

--- a/almdrlib/session.py
+++ b/almdrlib/session.py
@@ -167,6 +167,7 @@ class Session():
                 auth_info = response.json()
                 account_info = auth_info["authentication"]["account"]
                 self._token = auth_info["authentication"]["token"]
+                logger.info(f'Authenticated user {auth_info["authentication"]["user"]["id"]}')
 
             except requests.exceptions.HTTPError as e:
                 raise AuthenticationException(f"invalid http response {e}")
@@ -281,13 +282,19 @@ class Session():
         if self._token is None:
             self._authenticate()
 
-        headers.update({'x-aims-auth-token': self._token})
+        # it's too easy to include the AIMS token when pasting debug logs, so redact it in
+        # the logging statement.
+        headers.update({'x-aims-auth-token': "REDACTED"})
+
         logger.debug(f"Calling '{method}' method. " +
                      f"URL: '{url}'. " +
                      f"Params: '{params}' " +
                      f"Headers: '{headers}' " +
                      f"Cookies: '{cookies}' " +
                      f"Args: '{kwargs}'")
+
+        headers.update({'x-aims-auth-token': self._token})
+
         response = self._session.request(
                 method, url,
                 params=params,


### PR DESCRIPTION
After

```
2020-10-02 05:09:29,861 - MainThread - almdrlib.session - INFO - Authenticated user 97367336-50CE-402D-A1F5-C59E1D79194D
[...]
2020-10-02 05:09:29,862 - MainThread - almdrlib.session - DEBUG - Calling 'get' method. URL: 'https://api.global-services.global.alertlogic.com/endpoints/v1/2/residency/default/services/policies/endpoint'. Params: '{}' Headers: '{'x-aims-auth-token': 'REDACTED'}' Cookies: '{}' Args: '{}'
[...]
```

Closes alertlogic/alcli#17