### PR TITLE
Don't duplicate logger hander

### DIFF
--- a/almdrlib/__init__.py
+++ b/almdrlib/__init__.py
@@ -36,7 +36,10 @@ def set_logger(name='almdrlib', level=logging.DEBUG, format_string=None):
     handler.setLevel(level)
     formatter = logging.Formatter(format_string)
     handler.setFormatter(formatter)
-    logger.addHandler(handler)
+
+    # avoid duplicate logs if already set by caller, etc.
+    if not logger.handlers:
+        logger.addHandler(handler)
 
 
 def _get_default_session():


### PR DESCRIPTION
Before
```
2020-10-02 09:05:13,484 - MainThread - almdrlib.session - DEBUG - 'get' method for URL: 'https://api.global-services.global.alertlogic.com/endpoints/v1/2/residency/default/services/policies/endpoint' returned '200' status code in '0.04141' seconds
DEBUG:almdrlib.session:'get' method for URL: 'https://api.global-services.global.alertlogic.com/endpoints/v1/2/residency/default/services/policies/endpoint' returned '200' status code in '0.04141' seconds
```

42 lines logged:
```
$ ~/Projects/al/alcli/alcli/alertlogic_cli.py --debug policies list_policies --account_id 2  2>&1 1>/dev/null | wc
      42     519    6587
```

After
```
DEBUG:almdrlib.session:'get' method for URL: 'https://api.global-services.global.alertlogic.com/endpoints/v1/2/residency/default/services/policies/endpoint' returned '200' status code in '0.043169' seconds
```

21 lines logged:
```
$ ~/Projects/al/alcli/alcli/alertlogic_cli.py --debug policies list_policies --account_id 2  2>&1 1>/dev/null | wc
      21     165    2842
```