### PR TITLE
Don't overwrite types.ModuleType

### DIFF
--- a/almdrlib/session.py
+++ b/almdrlib/session.py
@@ -5,8 +5,6 @@
     ~~~~~~~~~~~~~~~~
     almdrlib authentication/authorization
 """
-import types
-import os
 import logging
 
 import requests
@@ -218,7 +216,6 @@ class Session():
 
         # Create Service's module
         module_name = service_name.capitalize()
-        types.ModuleType = module_name
         class_name = "Client"
 
         #


### PR DESCRIPTION
Don't overwrite types.ModuleType.  I can't find any reason this was done in the first place.  This broke any call I could come up with to the `help(...)` function:

Before:
```
Python 3.9.2 (default, Feb 24 2021, 13:30:36)
[Clang 12.0.0 (clang-1200.0.32.29)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import almdrlib
>>> c = almdrlib.client('search')
>>> help(str.join)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/Cellar/python@3.9/3.9.2_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/_sitebuiltins.py", line 103, in __call__
    return pydoc.help(*args, **kwds)
  File "/usr/local/Cellar/python@3.9/3.9.2_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/pydoc.py", line 2001, in __call__
    self.help(request)
  File "/usr/local/Cellar/python@3.9/3.9.2_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/pydoc.py", line 2060, in help
    else: doc(request, 'Help on %s:', output=self._output)
  File "/usr/local/Cellar/python@3.9/3.9.2_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/pydoc.py", line 1779, in doc
    pager(render_doc(thing, title, forceload))
  File "/usr/local/Cellar/python@3.9/3.9.2_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/pydoc.py", line 1753, in render_doc
    desc = describe(object)
  File "/usr/local/Cellar/python@3.9/3.9.2_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/pydoc.py", line 1683, in describe
    if inspect.ismodule(thing):
  File "/usr/local/Cellar/python@3.9/3.9.2_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/inspect.py", line 71, in ismodule
    return isinstance(object, types.ModuleType)
TypeError: isinstance() arg 2 must be a type or tuple of types
```

After:
```
Python 3.9.2 (default, Feb 24 2021, 13:30:36)
[Clang 12.0.0 (clang-1200.0.32.29)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import almdrlib
>>> c = almdrlib.client('search')
>>> help(str.join)

>>>
```

(The pager comes up to display help, so its output isn't displayed here.  But `help` works as expected.)
