### PR TITLE
For each operation call try to resolve proper service endpoint if acc…

### DIFF
--- a/almdrlib/client.py
+++ b/almdrlib/client.py
@@ -43,10 +43,13 @@ class Server(object):
 
         if spec.get(OpenAPIKeyWord.X_ALERTLOGIC_SESSION_ENDPOINT) and \
                 self._session:
-            self._url = self._session.get_url(self._service_name)
+            self.update_url()
 
         logger.debug(f"Server initialized using '{self._url}' URL " +
                      f"for '{self._service_name}' service.")
+
+    def update_url(self, account_id=None):
+        self._url = self._session.get_url(self._service_name, account_id)
 
     @property
     def url(self):
@@ -577,6 +580,10 @@ class Operation(object):
             params = {}
             headers = {}
             cookies = {}
+            account_id = kwargs.get('account_id')
+
+            if account_id:
+                self._server.update_url(account_id)
 
             logger.debug(
                     f"{self.operation_id} called " +


### PR DESCRIPTION
### Problem
Server object resolves final service URL in accordance to the account id using account id from the session, but calls to the services might be invoked by user allowed to access other accounts.

### Resolution
Every tie when operation call is generated, check if account_id is passed as an argument to the operation and if so, discover proper service endpoint using provided account id. 