### PR TITLE
Support byte RequestBodySimpleParameter

### DIFF
--- a/almdrlib/client.py
+++ b/almdrlib/client.py
@@ -158,7 +158,7 @@ class RequestBodySimpleParameter(RequestBodyParameter):
 
     def serialize(self, kwargs, header=None):
         data = kwargs.pop(self.name, "")
-        if self._format == 'binary':
+        if self._format == 'binary' and not isinstance(data, bytes):
             kwargs['data'] = data.encode()
         else:
             kwargs['data'] = data


### PR DESCRIPTION
Problem to solve:

- Passing actual binary in RequestBodySimpleParameter as a string messes up with them as they are interpreted as utf8 strings

Proposed solution:

- Support bytes in RequestBodySimpleParameter