### PR TITLE
pyyaml: pin to 5.4.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ setuptools>=42
 pip>=19.0.3
 requests==2.22.0
 configparser==4.0.2
-pyyaml>=5.4.1
+pyyaml==5.4.1
 jsonschema[format_nongpl]==3.2.0
 git+https://github.com/crossnox/m2r@dev#egg=m2r
 boto3>=1.16.57


### PR DESCRIPTION
Letting pyyaml float above 5.4.1 breaks something in the build process.