### PR TITLE
Improve generated documentation for client methods

### DIFF
--- a/almdrlib/client.py
+++ b/almdrlib/client.py
@@ -497,6 +497,9 @@ class PathParameter(object):
         kwargs = {}
         if self.default is not None:
             kwargs['default'] = self.default
+        annotation = openapi_type_to_python_data_type(self.datatype)
+        if annotation:
+            kwargs['annotation'] = annotation
         return inspect.Parameter(self._name, inspect.Parameter.KEYWORD_ONLY,
                                  **kwargs)
 
@@ -954,3 +957,14 @@ def serialize_value(datatype, value):
         return value and "true" or "false"
     else:
         return str(value)
+
+
+def openapi_type_to_python_data_type(data_type):
+    type_map = {
+        OpenAPIKeyWord.STRING: str,
+        OpenAPIKeyWord.BOOLEAN: bool,
+        OpenAPIKeyWord.INTEGER: int,
+        OpenAPIKeyWord.OBJECT: dict,
+        OpenAPIKeyWord.ARRAY: list
+    }
+    return type_map.get(data_type)

--- a/almdrlib/client.py
+++ b/almdrlib/client.py
@@ -712,7 +712,9 @@ class Operation(object):
             # Define the body parameter, if it exists
             if self.body is not None:
                 # Define the content type parameter if there's more than one
-                if not self.body.default_content_type:
+                ct_present = OpenAPIKeyWord.CONTENT_TYPE_PYTHON_PARAM in \
+                             [p.name for p in self._params]
+                if not self.body.default_content_type and not ct_present:
                     param = inspect.Parameter(
                         OpenAPIKeyWord.CONTENT_TYPE_PYTHON_PARAM,
                         inspect.Parameter.KEYWORD_ONLY)

--- a/almdrlib/client.py
+++ b/almdrlib/client.py
@@ -721,7 +721,7 @@ class Operation(object):
         body_params = []
         non_required_params = []
         # Define the path, query, header, and cookie parameters
-        for p in self._params:
+        for p in sorted(self._params):
             if p.required:
                 required_params.append(p.to_inspect_parameter())
             else:

--- a/almdrlib/client.py
+++ b/almdrlib/client.py
@@ -303,8 +303,9 @@ class RequestBody(object):
             content_type = headers[OpenAPIKeyWord.CONTENT_TYPE_PARAM]
             payload_body_param = self._content[content_type]
         elif self.default_content_type:
-            payload_body_param = self._content[self.default_content_type]
-            headers[OpenAPIKeyWord.CONTENT_TYPE_PARAM] = self.default_content_type
+            ct = self.default_content_type
+            payload_body_param = self._content[ct]
+            headers[OpenAPIKeyWord.CONTENT_TYPE_PARAM] = ct
         else:
             raise AlmdrlibValueError(
                 f"'{OpenAPIKeyWord.CONTENT_TYPE_PYTHON_PARAM}'" +

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -2,63 +2,50 @@
 
 import almdrlib
 import os
-import json
 import inspect
 
 """Tests for `alertlogic-sdk-python` package."""
 
 import unittest
 
-from almdrlib.session import Session
-from almdrlib.client import Client
-from almdrlib.client import Config
-from almdrlib.client import Operation
-from alsdkdefs import OpenAPIKeyWord
-
 
 class TestSdk_open_api_support(unittest.TestCase):
-    """Tests for `python_boilerplate` package."""
+    """Tests for documentation generation."""
 
     def setUp(self):
         """Set up test fixtures, if any."""
         dir_path = os.path.dirname(os.path.realpath(__file__))
         os.environ["ALERTLOGIC_API"] = f"{dir_path}/apis"
         self._service_name = "testapi"
-
-        test_data_file = None
-        test_data_file_path = f"{dir_path}/data/test_open_api_support.json"
-        with open(test_data_file_path, "r") as value_file:
-            test_data_file = value_file.read()
-
-        self.test_data = json.loads(test_data_file)
-
-    def tearDown(self):
-        """Tear down test fixtures, if any."""
+        self._account_id = '2'
+        self._session = almdrlib.session.Session(account_id=self._account_id, global_endpoint='https://example.net')
 
     def test_000_get_signature(self):
         """Test the signature for test_get_data."""
-        client = almdrlib.client('testapi')
+        client = almdrlib.client('testapi', session=self._session)
+        # Order matters - path paramters first (account_id), then query params, then header params.
+        # AlertLogic doesn't use Cookie parameters generally, but they'd be last.
         test_get_data_sig = inspect.Signature([
-            inspect.Parameter('header_param1', inspect.Parameter.KEYWORD_ONLY, annotation=str),
+            inspect.Parameter('account_id', inspect.Parameter.KEYWORD_ONLY, annotation=str, default=self._account_id),
             inspect.Parameter('query_param1', inspect.Parameter.KEYWORD_ONLY, annotation=str),
-            inspect.Parameter('account_id', inspect.Parameter.KEYWORD_ONLY, annotation=str, default='2'),
-            inspect.Parameter('header_param2', inspect.Parameter.KEYWORD_ONLY, annotation=int),
             inspect.Parameter('query_param2', inspect.Parameter.KEYWORD_ONLY, annotation=list),
             inspect.Parameter('query_param3', inspect.Parameter.KEYWORD_ONLY, annotation=dict),
+            inspect.Parameter('header_param1', inspect.Parameter.KEYWORD_ONLY, annotation=str),
+            inspect.Parameter('header_param2', inspect.Parameter.KEYWORD_ONLY, annotation=int),
         ])
         self.assertEqual(test_get_data_sig, client.test_get_data.__signature__)
 
     def test_001_post_signature(self):
         """Test the signature for post_payload_in_body."""
-        client = almdrlib.client('testapi')
+        client = almdrlib.client('testapi', session=self._session)
         post_payload_in_body_sig = inspect.Signature([
-            inspect.Parameter('account_id', inspect.Parameter.KEYWORD_ONLY, annotation=str, default='2'),
+            inspect.Parameter('account_id', inspect.Parameter.KEYWORD_ONLY, annotation=str, default=self._account_id),
+            inspect.Parameter('content_type', inspect.Parameter.KEYWORD_ONLY, annotation=str, default='application/json'),
             inspect.Parameter('payload', inspect.Parameter.KEYWORD_ONLY),
-            inspect.Parameter('content_type', inspect.Parameter.KEYWORD_ONLY, annotation=str, default='application/json')
         ])
         self.assertEqual(post_payload_in_body_sig, client.post_payload_in_body.__signature__)
 
     def test_002_doc_body(self):
         """Validate that the description is somewhere in the documentation."""
-        client = almdrlib.client('testapi')
+        client = almdrlib.client('testapi', session=self._session)
         self.assertIn(client.test_get_data.description, client.test_get_data.__doc__)

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+
+import almdrlib
+import os
+import json
+import inspect
+
+"""Tests for `alertlogic-sdk-python` package."""
+
+import unittest
+
+from almdrlib.session import Session
+from almdrlib.client import Client
+from almdrlib.client import Config
+from almdrlib.client import Operation
+from alsdkdefs import OpenAPIKeyWord
+
+
+class TestSdk_open_api_support(unittest.TestCase):
+    """Tests for `python_boilerplate` package."""
+
+    def setUp(self):
+        """Set up test fixtures, if any."""
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+        os.environ["ALERTLOGIC_API"] = f"{dir_path}/apis"
+        self._service_name = "testapi"
+
+        test_data_file = None
+        test_data_file_path = f"{dir_path}/data/test_open_api_support.json"
+        with open(test_data_file_path, "r") as value_file:
+            test_data_file = value_file.read()
+
+        self.test_data = json.loads(test_data_file)
+
+    def tearDown(self):
+        """Tear down test fixtures, if any."""
+
+    def test_000_get_signature(self):
+        """Test the signature for test_get_data."""
+        client = almdrlib.client('testapi')
+        test_get_data_sig = inspect.Signature([
+            inspect.Parameter('header_param1', inspect.Parameter.KEYWORD_ONLY, annotation=str),
+            inspect.Parameter('query_param1', inspect.Parameter.KEYWORD_ONLY, annotation=str),
+            inspect.Parameter('account_id', inspect.Parameter.KEYWORD_ONLY, annotation=str, default='2'),
+            inspect.Parameter('header_param2', inspect.Parameter.KEYWORD_ONLY, annotation=int),
+            inspect.Parameter('query_param2', inspect.Parameter.KEYWORD_ONLY, annotation=list),
+            inspect.Parameter('query_param3', inspect.Parameter.KEYWORD_ONLY, annotation=dict),
+        ])
+        self.assertEqual(test_get_data_sig, client.test_get_data.__signature__)
+
+    def test_001_post_signature(self):
+        """Test the signature for post_payload_in_body."""
+        client = almdrlib.client('testapi')
+        post_payload_in_body_sig = inspect.Signature([
+            inspect.Parameter('account_id', inspect.Parameter.KEYWORD_ONLY, annotation=str, default='2'),
+            inspect.Parameter('payload', inspect.Parameter.KEYWORD_ONLY),
+            inspect.Parameter('content_type', inspect.Parameter.KEYWORD_ONLY, annotation=str, default='application/json')
+        ])
+        self.assertEqual(post_payload_in_body_sig, client.post_payload_in_body.__signature__)
+
+    def test_002_doc_body(self):
+        """Validate that the description is somewhere in the documentation."""
+        client = almdrlib.client('testapi')
+        self.assertIn(client.test_get_data.description, client.test_get_data.__doc__)


### PR DESCRIPTION
The `help(...)` for client Operations is terrible:

```
help(aims_client.get_account_relationship_topology) -> (in a pager)

Help on Operation in module almdrlib.client object:

class Operation(builtins.object)
 |  Operation(path, params, summary, description, method, spec, body, response, session=None, server=None)
 |
 |  Methods defined here:
 |
 |  __call__(self, *args, **kwargs)
 |      Call self as a function.
 |
 |  __init__(self, path, params, summary, description, method, spec, body, response, session=None, server=None)
 |      Initialize self.  See help(type(self)) for accurate signature.
 |
 |  __repr__(self)
 |      Return repr(self).
 |
 |  get_schema(self)
 |
 |  url(self, **kwargs)
 |
 |  ----------------------------------------------------------------------
 |  Readonly properties defined here:
 |
 |  body
 |
 |  description
 |
 |  method
 |
 |  operation_id
 |
 |  params
 |
 |  path
 |
 |  spec
 |
 |  ----------------------------------------------------------------------
 |  Data descriptors defined here:
 |
 |  __dict__
 |      dictionary for instance variables (if defined)
 |
 |  __weakref__
 |      list of weak references to the object (if defined)
```

This change creates a signature for the operation and uses the description string to make useful documentation:

```
help(aims_client.get_account_relationship_topology) -> (in a pager)

Help on Operation in module almdrlib.client object:

get_account_relationship_topology = <aims.get_account_relationship_topology: GET /aims/v1/{account_id}/accounts/{relationship}/topology>
    get_account_relationship_topology(*, account_id: str = '2', relationship: str, accessible_locations: str, active: bool, fields: str)

    Required parameters:
    * relationship

    This endpoint render's an accounts related accounts topologically by adding a `:relationship`
    field to the account object, which contains an array of accounts that are directly related to it.
    In turn, each of those accounts is decorated with a `:relationship` field that contains the
    (similarly decorated) accounts directly related to it. This continues recursively till a "leaf"
    account (an account with no direct relationships) is decorated with `{"<relationship>": []}`.
    Clients may use this endpoint to understand how an accounts related accounts are related to
    each other, e.g., understanding "direct descendants," "direct ancestors," "grand ancestors," etc.

    Note that the `managing` account relationship is the inverse of the `managed` relationship. That
    is, looking up the `managing` relationship returns the list of accounts that have a `managed`
    relationship to the given `account_id`. This list shows **only** accounts which the calling client
    is authorized to view, so, for example, looking up `managing` accounts for the client's own
    account will result in an empty topology regardless of whether accounts not visible to
    the client have a `managed` relationship to the given `account_id`.
```

The signature shows defaults and basic type hints.  The documentation is taken directly from the OpenAPI, including any text wrapping (or lack thereof).