### PR TITLE
Use AlmdrlibValueError instead of Exception

### DIFF
--- a/almdrlib/client.py
+++ b/almdrlib/client.py
@@ -692,8 +692,8 @@ class Operation(object):
             self._call = self._gen_call()
         try:
             return self._call(*args, **kwargs)
-        except Exception as e:
-            raise Exception(f"{self} failed {e}")
+        except AlmdrlibValueError as e:
+            raise AlmdrlibValueError(f'{self} failed {e}')
 
     def __repr__(self):
         return f"<{self._client.name}.{self.operation_id}: " \


### PR DESCRIPTION
### Description

Printing of `Exception`s is not safe. `AlmdrlibValueError` should have been raised in the first place.

#### Current 
```
alcli --profile integration aetuner update_tagset --account_id 134249387 --path tuning/ngx/ConfigChange/AttackerKeyAccountNameWhitelist --xtuning '[{"type":"test","operation":"delete","path":"tuning/ngx/ConfigChange/AttackerKeyAccountNameWhitelist","key":"config_change"]}]' --reason "wrong type" --dry_run=true
ERROR:root:Expecting ',' delimiter: line 1 column 124 (char 123)
ERROR:alcli.almdr_cli:An exception of type Exception occurred. Arguments:
('<aetuner.update_tagset: POST /v1/{account_id}/tagsets> failed Validation Error: \'[{"type":"test","operation":"delete","path":"tuning/ngx/ConfigChange/AttackerKeyAccountNameWhitelist","key":"config_change"]}]\' is not of type \'array\'',)
Traceback (most recent call last):
  File "/Users/acockfield/Library/Python/3.9/lib/python/site-packages/almdrlib/client.py", line 694, in __call__
    return self._call(*args, **kwargs)
  File "/Users/acockfield/Library/Python/3.9/lib/python/site-packages/almdrlib/client.py", line 670, in f
    self._body.serialize(headers, kwargs)
  File "/Users/acockfield/Library/Python/3.9/lib/python/site-packages/almdrlib/client.py", line 314, in serialize
    payload_body_param.serialize(kwargs, headers)
  File "/Users/acockfield/Library/Python/3.9/lib/python/site-packages/almdrlib/client.py", line 227, in serialize
    self.validate(result)
  File "/Users/acockfield/Library/Python/3.9/lib/python/site-packages/almdrlib/client.py", line 127, in validate
    raise AlmdrlibValueError(f"Validation Error: {e.message}") from None
almdrlib.exceptions.AlmdrlibValueError: Validation Error: '[{"type":"test","operation":"delete","path":"tuning/ngx/ConfigChange/AttackerKeyAccountNameWhitelist","key":"config_change"]}]' is not of type 'array'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/acockfield/Library/Python/3.9/lib/python/site-packages/alcli/alertlogic_cli.py", line 116, in main
    return services[parsed_args.service](remaining, parsed_args)
  File "/Users/acockfield/Library/Python/3.9/lib/python/site-packages/alcli/alertlogic_cli.py", line 199, in __call__
    res = operation(**op_args)
  File "/Users/acockfield/Library/Python/3.9/lib/python/site-packages/almdrlib/client.py", line 696, in __call__
    raise Exception(f"{self} failed {e}")
Exception: <aetuner.update_tagset: POST /v1/{account_id}/tagsets>
failed Validation Error:
'[{"type":"test","operation":"delete","path":"tuning/ngx/ConfigChange/AttackerKeyAccountNameWhitelist","key":"config_change"]}]' is not of type 'array
```

#### New

```shell
ERROR:root:Expecting ',' delimiter: line 1 column 124 (char 123)
<aetuner.update_tagset: POST /v1/{account_id}/tagsets> failed Validation Error: '[{"type":"test","operation":"delete","path":"tuning/ngx/ConfigChange/AttackerKeyAccountNameWhitelist","key":"config_change"]}]' is not of type 'array
```
