### PR TITLE
Use current m2r2 instead of old, broken m2r==0.2.1

### DIFF
--- a/almdrlib/docs/service.py
+++ b/almdrlib/docs/service.py
@@ -2,7 +2,7 @@ import json
 import logging
 import itertools
 try:
-    from m2r import convert
+    from m2r2 import convert
 except Exception:
     def convert(text):
         return text

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,7 +41,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinxcontrib.contentui',
     'sphinx_paramlinks',
-    'm2r'
+    'm2r2'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 Sphinx==3.0.1
-git+https://github.com/crossnox/m2r@dev#egg=m2r
+m2r2==0.3.2
 sphinx_rtd_theme==0.4.3
 sphinxcontrib_contentui==0.2.4
 sphinx-paramlinks==0.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ requests==2.22.0
 configparser==4.0.2
 pyyaml>=5.4.1
 jsonschema[format_nongpl]==3.2.0
-git+https://github.com/crossnox/m2r@dev#egg=m2r
+m2r2==0.3.2
 boto3>=1.16.57

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,5 +14,5 @@ configparser==4.0.2
 sphinx_rtd_theme==0.4.3
 sphinxcontrib_contentui==0.2.4
 sphinx-paramlinks==0.4.1
-git+https://github.com/crossnox/m2r@dev#egg=m2r
+m2r2==0.3.2
 boto3>=1.16.57

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ requirements = [
         'configparser>=4.0.2',
         'pyyaml>=5.4.1',
         'jsonschema[format_nongpl]==3.2.0',
-        'm2r==0.2.1',
+        'm2r2==0.3.2',
         'boto3>=1.16.57',
         definitions_dependency
     ]


### PR DESCRIPTION
The old dependency seems to be breaking downstream builds:

```
Collecting m2r==0.2.1  
  ...
    AttributeError: module 'mistune' has no attribute 'BlockGrammar'
```

Osin please accept!

