### PR TITLE
fix multiple content type issue for requestBody

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,12 @@ for line in sys.stdin:
 endef
 export PRINT_HELP_PYSCRIPT
 
-BROWSER := python -c "$$BROWSER_PYSCRIPT"
+PYTHON := python
+BROWSER := $(PYTHON) -c "$$BROWSER_PYSCRIPT"
+PIP := pip
 
 help:
-	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
+	@$(PYTHON) -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
 
 clean: clean-build clean-pyc clean-test ## remove all build, test, coverage and Python artifacts
 
@@ -51,7 +53,7 @@ lint: ## check style with flake8
 	flake8 almdrlib tests
 
 test: ## run tests quickly with the default Python
-	python setup.py test
+	$(PYTHON) setup.py test
 	
 test-all: ## run tests on every Python version with tox
 	tox
@@ -78,11 +80,11 @@ release: dist ## package and upload a release
 	twine upload --skip-existing dist/alertlogic-sdk-python-*.* dist/*
 
 dist: clean ## builds source and wheel package
-	python setup.py sdist
+	$(PYTHON) setup.py sdist
 
 install: clean ## install the package to the active Python's site-packages
-	python setup.py install
+	$(PYTHON) setup.py install
 
 uninstall:  ## uninstall the package from the active Python's site-packages
-	pip uninstall alertlogic-sdk-python -y
+	$(PIP) uninstall alertlogic-sdk-python -y
 

--- a/tests/apis/testapi/testapi.v1.yaml
+++ b/tests/apis/testapi/testapi.v1.yaml
@@ -84,6 +84,35 @@ paths:
               name: payload
               encoding:
                 explode: true
+
+  /testapi/v1/{account_id}/test_multiple_content_types:
+    post:
+      operationId: test_multiple_content_types
+      requestBody:
+        required: true
+        content:
+          text/csv:
+            schema:
+              type: object
+          application/json:
+            examples:
+            schema:
+              type: object
+      summary: Import protection scope
+      description: |-
+        Endpoint for importing the protection scope of a deployment.
+      parameters:
+        - schema:
+            type: string
+          name: account_id
+          in: path
+          required: true
+          description: AIMS Account ID
+
+      responses:
+        '200':
+          description: OK
+
 components:
   schemas:
     SimpleDataTypesModel:


### PR DESCRIPTION
### Problem
The alcli crashes if there is an OpenAPI specification for requestBody with multiple options for content-type.

```
alcli
Traceback (most recent call last):
  File "/Users/daniel.zinov/bin/alcli", line 8, in <module>
    sys.exit(main())
  File "/Users/daniel.zinov/Library/Python/3.9/lib/python/site-packages/alcli/alertlogic_cli.py", line 320, in main
    cli.main()
  File "/Users/daniel.zinov/Library/Python/3.9/lib/python/site-packages/alcli/alertlogic_cli.py", line 85, in main
    parsed_args, remaining = parser.parse_known_args(args)
  File "/Users/daniel.zinov/Library/Python/3.9/lib/python/site-packages/alcli/cliparser.py", line 115, in parse_known_args
    parsed_args, remaining = super().parse_known_args(args, namespace)
  File "/usr/local/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/argparse.py", line 1854, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "/usr/local/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/argparse.py", line 2066, in _parse_known_args
    stop_index = consume_positionals(start_index)
  File "/usr/local/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/argparse.py", line 2022, in consume_positionals
    take_action(action, args)
  File "/usr/local/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/argparse.py", line 1931, in take_action
    action(self, namespace, argument_values, option_string)
  File "/usr/local/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/argparse.py", line 1210, in __call__
    subnamespace, arg_strings = parser.parse_known_args(arg_strings, None)
  File "/Users/daniel.zinov/Library/Python/3.9/lib/python/site-packages/alcli/cliparser.py", line 147, in parse_known_args
    service_api = self._service.get_service_api(self._service.name)
  File "/Users/daniel.zinov/Library/Python/3.9/lib/python/site-packages/alcli/alertlogic_cli.py", line 209, in get_service_api
    return Session.get_service_api(service_name=service_name)
  File "/Users/daniel.zinov/Library/Python/3.9/lib/python/site-packages/almdrlib/session.py", line 334, in get_service_api
    operations[op_name] = operation.get_schema()
  File "/Users/daniel.zinov/Library/Python/3.9/lib/python/site-packages/almdrlib/client.py", line 629, in get_schema
    params_schema['content_type'].update(
KeyError: 'content_type'
```

### Solution
Require content_type parameter. Use this parameter to choose the correct schema for validation and serialisation

### Info
alcli program structure:
```
alcli
	_create_parser()
		ALCliArgsParser.parse_known_args()
			ServicesArgsParser.parse_known_args()
				Session.get_service_api()
					Operation:get_schema()
						RequestBody:get_schema()
				OperationArgsParser.make_parameter_argument()


	_init_service
		ServiceOperation
			Client.__init__
				Client.load_service_spec
					Client.load_spec
						Client._initialize_operations
							_initalize_request_body
								RequestBody.add_content(content_type, schema)
							Operation

	ServiceOperation.call()
		Operation.call()
			PathParameter.serialize()
			RequestBody.serialize() - know content-type
				RequestBodySchemaParameter.serialize()
					RequestBodySchemaParameter.validate()
```
### Related
https://github.com/alertlogic/alcli/pull/58