### PR TITLE
fix alertlogic.com/json serialization

### DIFF
--- a/almdrlib/client.py
+++ b/almdrlib/client.py
@@ -152,7 +152,7 @@ class RequestBodySchemaParameter(RequestBodyParameter):
 
     def serialize(self, kwargs, header=[]):
         data = kwargs.pop(self.name, {})
-        json_content_types = ['application/json', 'alertlogic/json']
+        json_content_types = ['application/json', 'alertlogic/json', 'alertlogic.com/json']
         if self.content_type in json_content_types:    
             self.validate(data)
             kwargs['data'] = json.dumps(data)

--- a/tests/apis/testapi/testapi.v1.yaml
+++ b/tests/apis/testapi/testapi.v1.yaml
@@ -113,6 +113,56 @@ paths:
         '200':
           description: OK
 
+  /testapi/v1/{account_id}/test_json_array_serialization:
+    post:
+      operationId: test_json_array_serialization
+      requestBody:
+        required: true
+        content:
+          alertlogic/json:
+            schema:
+              type: array
+            x-alertlogic-schema:
+              name: payload
+              encoding:
+                explode: true
+          alertlogic.com/json:
+            schema:
+              type: array
+            x-alertlogic-schema:
+              name: payload
+              encoding:
+                explode: true
+          application/json:
+            schema:
+              type: array
+            x-alertlogic-schema:
+              name: payload
+              encoding:
+                explode: true
+      summary: Import protection scope
+      description: |-
+        Endpoint for importing the protection scope of a deployment.
+      parameters:
+        - schema:
+            type: string
+          name: account_id
+          in: path
+          required: true
+          description: AIMS Account ID
+        - schema:
+            type: string
+          enum:
+            - application/json
+            - alertlogic/json
+            - alertlogic.com/json
+          in: header
+          name: content-type
+          required: true
+      responses:
+        '200':
+          description: OK
+
 components:
   schemas:
     SimpleDataTypesModel:

--- a/tests/test_open_api_support.py
+++ b/tests/test_open_api_support.py
@@ -83,3 +83,14 @@ class TestSdk_open_api_support(unittest.TestCase):
         self.assertIsInstance(Session(), Session)
         self.assertIsInstance(Config(), Config)
         self.assertIsInstance(Client(self._service_name), Client)
+
+    def test_003_json_array_serialization(self):
+        """Checks json array serilisation works for all supported content types"""
+        client = Client(self._service_name)
+        operation = client.operations.get('test_json_array_serialization')
+        payload = [{'allthethings': '42'}]
+        for content_type in ['application/json', 'alertlogic/json', 'alertlogic.com/json']:
+            kwargs = {'payload': payload}
+            headers = {'content-type': content_type}
+            operation.body.serialize(headers, kwargs)
+            self.assertEqual(kwargs['data'], json.dumps(payload))


### PR DESCRIPTION
### Problem
https://github.com/alertlogic/alertlogic-sdk-python/pull/111 broke json array body serialization in case of `alertlogic.com/json` content type
this case is required for ingest:  https://github.com/alertlogic/alertlogic-sdk-definitions/blob/5e8003bbb2c4a5abcb0df05f328861f25cceedb1/alsdkdefs/apis/ingest/ingest.v1.yaml#L136

### Solution
fix it