### PR TITLE
Cache service/account endpoints lookup

### DIFF
--- a/almdrlib/session.py
+++ b/almdrlib/session.py
@@ -16,6 +16,7 @@ from almdrlib.config import Config
 from almdrlib.region import Region
 from almdrlib.client import Client
 import alsdkdefs
+from functools import lru_cache
 
 logger = logging.getLogger(__name__)
 
@@ -246,7 +247,19 @@ class Session():
             " class instance")
         return _client
 
+    @lru_cache(maxsize=128)
     def get_url(self, service_name, account_id=None):
+        """
+        Lookup account-specific URL prefix for a service
+
+        The host portion of each service URL can vary, based on the account_id of the
+        request. This function looks up the correct URL, via a static map or (usually)
+        the endpoints service. The result is cached. 
+
+        The URL consists of the protocol and hostname, for example
+        https://api.cloudinsight.alertlogic.com
+        """
+        
         if self._global_endpoint == "map":
             return self.get_mapped_url(service_name, account_id)
         elif re.match(r'^(http|https)://.*$', self._global_endpoint):


### PR DESCRIPTION
**Problem**

Looking up the endpoint for a (service, account ID) pair can involve a network roundtrip, but
is constant over execution timescales.

**Solution**

Use a small cache. After executing a script that iterates over 200 account IDs and runs 3 API calls for one service and 2 for another:

URL Cache stats: CacheInfo(hits=603, misses=403, maxsize=128, currsize=128)

