### PR TITLE
when creating an AL MDR python sdk config, check SSM for AIMS access key and secret

### DIFF
--- a/almdrlib/config.py
+++ b/almdrlib/config.py
@@ -116,8 +116,12 @@ class Config():
             if self._access_key_id is None or self._secret_key is None:
                 service_name_key = f"{service_name}.aims_authc",
                 env = AlEnv(service_name_key)
-                self._access_key_id = env.get('access_key_id')
-                self._secret_key = env.get('secret_access_key')
+                # attempt SSM first, then dynamoDB
+                self._access_key_id = env.get_parameter('access_key_id', decrypt=True)
+                self._secret_key = env.get_parameter('secret_access_key', decrypt=True)
+                if self._access_key_id is None or self._secret_key is None:
+                    self._access_key_id = env.get('access_key_id')
+                    self._secret_key = env.get('secret_access_key')
         except Exception as e:
             logger.debug(f"Did not initialise aims credentials for {service_name} because {e}")
 

--- a/almdrlib/environment.py
+++ b/almdrlib/environment.py
@@ -59,6 +59,7 @@ class AlEnv:
             self.dynamodb = boto3.resource('dynamodb')
             self.table = self.dynamodb.Table(self.table_name)
             self._table_date_time = self.table.creation_date_time
+            self.ssm = boto3.client('ssm')
         except botocore.exceptions.ClientError as e:
             if e.response['Error']['Code'] == 'ResourceNotFoundException':
                 raise AlEnvConfigurationTableUnavailableException(self.table_name)
@@ -74,6 +75,16 @@ class AlEnv:
             return converted
         else:
             return default
+
+    def get_parameter(self, key, default=None, decrypt=False):
+        try:
+            parameter = self.ssm.get_parameter(Name=self._make_ssm_key(key), WithDecryption=decrypt)
+        except self.ssm.exceptions.ParameterNotFound:
+            return default
+        return parameter["Parameter"]["Value"]
+
+    def _make_ssm_key(self, option_key):
+        return f"/deployments/{self._get_region()}/env-settings/{self._make_ddb_key(option_key)}"
 
     def _make_ddb_key(self, option_key):
         return f"{self.application_name}.{option_key}"

--- a/almdrlib/environment.py
+++ b/almdrlib/environment.py
@@ -1,5 +1,5 @@
 '''Cloud stored environment configuration
-AlEnv class implements retrieval and formatting of configuration parameters from dynamodb in the standardized way.
+AlEnv class implements retrieval and formatting of configuration parameters from SSM parameter store & dynamodb in the standardized way.
 AWS client used is configured as follows https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html
 Therefore, AWS cli configuration would be automatically picked up.
 The simpliest way is to use environment variables.
@@ -29,6 +29,12 @@ Usage:
 # Assuming parameter is stored in ddb as '"true"'
 >> env.get("my_parameter", type='boolean')
 True
+# For String types in SSM:
+>> env.get_parameter("my_parameter")
+'value'
+# For SecureString types in SSM:
+>> env.get_parameter("my_parameter", decrypt=True)
+'value'
 '''
 
 import json

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -30,10 +30,38 @@ class MockBotoDDB:
     def __init__(self, client_type):
         pass
 
+class SSMExceptions:
+
+    class ParameterNotFound(Exception):
+        pass
+
+class MockBotoSSM:
+
+    exceptions = SSMExceptions()
+
+    def __init__(self, client_type):
+        pass
+
+    @staticmethod
+    def get_parameter(**kwargs):
+        Name = kwargs.get('Name')
+        WithDecryption = kwargs.get('WithDecryption')
+
+        if Name == '/deployments/us-west-1/env-settings/someapplication.stringparam':
+            return {'Parameter': {'Value': 'testingtesting'}}
+        elif Name == '/deployments/us-west-1/env-settings/someapplication.securestringparam':
+            if WithDecryption:
+                return {'Parameter': {'Value': 'testingtestingtesting'}}
+            else:
+                return {'Parameter': {'Value': 'AQICAHhxjBnL9Dhpl/8CUT7/NC07HUYnX+P'}}
+        else:
+            raise MockBotoSSM.exceptions.ParameterNotFound()
+
 
 class TestAlEnv(unittest.TestCase):
     def test_something(self):
         boto3.resource = MagicMock(return_value=MockBotoDDB)
+        boto3.client = MagicMock(return_value=MockBotoSSM)
         os.environ['ALERTLOGIC_STACK_REGION'] = 'us-west-1'
         os.environ['ALERTLOGIC_STACK_NAME'] = 'production'
         env = AlEnv("someapplication")
@@ -47,7 +75,11 @@ class TestAlEnv(unittest.TestCase):
         assert env.get("boolkeytrue", type='boolean') is True
         assert env.get("floatkey") == '1.0'
         assert env.get("floatkey", type='float') == 1.0
-
+        assert env.get_parameter("stringparam") == 'testingtesting'
+        assert env.get_parameter("securestringparam") == 'AQICAHhxjBnL9Dhpl/8CUT7/NC07HUYnX+P'
+        assert env.get_parameter("securestringparam", decrypt=False) == 'AQICAHhxjBnL9Dhpl/8CUT7/NC07HUYnX+P'
+        assert env.get_parameter("securestringparam", decrypt=True) == 'testingtestingtesting'
+        assert env.get_parameter("invalidparam", "default") == 'default'
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When setting up the AL python SDK for an application, there are a few ways AIMS keys can be obtained:
- passed in as part of the creation call
- from a config file
- from environment variables
- from dynamodb

This change adds a check for keys in AWS SSM parameter store before checking dynamodb.
It checks the standard key names /deployments/[region]/env-settings/[service].aims_authc.(access_key_id|secret_access_key)
Therefore the ALERTLOGIC_STACK_REGION and ALERTLOGIC_SERVICE_NAME environment variables need to be set in the calling service (or a service name passed into the SDK setup call, in the case of the latter).