### PR TITLE
update to fix bugs/better implementation

### DIFF
--- a/almdrlib/config.py
+++ b/almdrlib/config.py
@@ -115,7 +115,7 @@ class Config():
         if self._access_key_id is None or self._secret_key is None:
             try:
                 # attempt ssm first
-                env = AlEnv(service_name, "aims_authc", ("ssm"))
+                env = AlEnv(service_name, "aims_authc", "ssm")
                 self._access_key_id = env.get_parameter('access_key_id', decrypt=True)
                 self._secret_key = env.get_parameter('secret_access_key', decrypt=True)
             except Exception as e:
@@ -123,7 +123,7 @@ class Config():
         if self._access_key_id is None or self._secret_key is None:
             try:
                 # if that doesn't work, attempt dynamodb
-                env = AlEnv(service_name, "aims_authc", ("dynamodb"))
+                env = AlEnv(service_name, "aims_authc", "dynamodb")
                 self._access_key_id = env.get('access_key_id')
                 self._secret_key = env.get('secret_access_key')
             except Exception as e:

--- a/almdrlib/config.py
+++ b/almdrlib/config.py
@@ -112,18 +112,23 @@ class Config():
                      f"global_endpoint={self._global_endpoint}")
 
     def _init_al_env_credentials(self, service_name):
-        try:
-            if self._access_key_id is None or self._secret_key is None:
-                service_name_key = f"{service_name}.aims_authc",
-                env = AlEnv(service_name_key)
-                # attempt SSM first, then dynamoDB
+        if self._access_key_id is None or self._secret_key is None:
+            try:
+                # attempt ssm first
+                env = AlEnv(service_name, "aims_authc", ("ssm"))
                 self._access_key_id = env.get_parameter('access_key_id', decrypt=True)
                 self._secret_key = env.get_parameter('secret_access_key', decrypt=True)
-                if self._access_key_id is None or self._secret_key is None:
-                    self._access_key_id = env.get('access_key_id')
-                    self._secret_key = env.get('secret_access_key')
-        except Exception as e:
-            logger.debug(f"Did not initialise aims credentials for {service_name} because {e}")
+            except Exception as e:
+                logger.debug(f"Did not initialise aims credentials via SSM for {service_name} because {e}")
+        if self._access_key_id is None or self._secret_key is None:
+            try:
+                # if that doesn't work, attempt dynamodb
+                env = AlEnv(service_name, "aims_authc", ("dynamodb"))
+                self._access_key_id = env.get('access_key_id')
+                self._secret_key = env.get('secret_access_key')
+            except Exception as e:
+                logger.debug(f"Did not initialise aims credentials via dynamodb for {service_name} because {e}")
+           
 
     def _read_config_file(self):
         try:

--- a/almdrlib/environment.py
+++ b/almdrlib/environment.py
@@ -54,27 +54,36 @@ class AlEnvAwsConfigurationException(AlEnvException):
 class AlEnvConfigurationTableUnavailableException(AlEnvException):
     pass
 
+class AlmdrlibSourceNotEnabledError(AlEnvException):
+    pass
+
 
 class AlEnv:
-    def __init__(self, application_name):
+    def __init__(self, application_name, client=None, sources=("dynamodb")):
         self.application_name = application_name
+        self.client = client
+        self.sources = sources
         self.region = AlEnv._get_region()
         self.stack_name = AlEnv._get_stack_name()
         self.table_name = AlEnv._table_name(self.region, self.stack_name)
         try:
             self.dynamodb = boto3.resource('dynamodb')
-            self.table = self.dynamodb.Table(self.table_name)
-            self._table_date_time = self.table.creation_date_time
             self.ssm = boto3.client('ssm')
-        except botocore.exceptions.ClientError as e:
-            if e.response['Error']['Code'] == 'ResourceNotFoundException':
-                raise AlEnvConfigurationTableUnavailableException(self.table_name)
-            else:
-                raise AlEnvException(e)
         except (botocore.exceptions.NoRegionError, botocore.exceptions.NoCredentialsError) as e:
             raise AlEnvAwsConfigurationException(f'Please validate your AWS configuration: {e}')
+        if "dynamodb" in sources:
+            try:
+                self.table = self.dynamodb.Table(self.table_name)
+                self._table_date_time = self.table.creation_date_time
+            except botocore.exceptions.ClientError as e:
+                if e.response['Error']['Code'] == 'ResourceNotFoundException':
+                    raise AlEnvConfigurationTableUnavailableException(self.table_name)
+                else:
+                    raise AlEnvException(e)
 
     def get(self, key, default=None, format='decoded', type=None):
+        if "dynamodb" not in self.sources:
+            raise AlmdrlibSourceNotEnabledError("dynamodb is not enabled for this environment")
         fetched_value = self.table.get_item(Key={"key": self._make_ddb_key(key)}).get('Item', {}).get('value')
         converted = AlEnv._convert(fetched_value, format, type)
         if converted is not None:
@@ -83,18 +92,28 @@ class AlEnv:
             return default
 
     def get_parameter(self, key, default=None, decrypt=False):
+        if "ssm" not in self.sources:
+            raise AlmdrlibSourceNotEnabledError("ssm is not enabled for this environment")
         try:
             parameter = self.ssm.get_parameter(Name=self._make_ssm_key(key), WithDecryption=decrypt)
         except self.ssm.exceptions.ParameterNotFound:
             return default
+        except botocore.exceptions.ClientError as e:
+            raise AlEnvException(e)
         return parameter["Parameter"]["Value"]
 
     def _make_ssm_key(self, option_key):
-        return f"/deployments/{self._get_region()}/env-settings/{self._make_ddb_key(option_key)}"
+        return f"/deployments/{self.stack_name}/{self._get_region()}/env-settings/{self.application_name}/{self._make_client_option_key()}"
 
     def _make_ddb_key(self, option_key):
-        return f"{self.application_name}.{option_key}"
+        return f"{self.application_name}.{self._make_client_option_key()}"
 
+    def _make_client_option_key(self, option_key):
+        if self.client is None:
+            return option_key
+        else:
+            return f"{self.client}.{option_key}"
+        
     @staticmethod
     def _convert(value, format, type):
         if format == 'raw' and value:

--- a/almdrlib/environment.py
+++ b/almdrlib/environment.py
@@ -75,7 +75,7 @@ class AlEnv:
             self.dynamodb = boto3.resource('dynamodb')
             self.ssm = boto3.client('ssm')
         except (botocore.exceptions.NoRegionError, botocore.exceptions.NoCredentialsError) as e:
-            raise AlEnvAwsConfigurationException(f'Please validate your AWS configuration: {e}')
+            raise AlEnvAwsConfigurationException(f'Please validate your AWS configuration') from e
         if "dynamodb" in source:
             try:
                 self.table = self.dynamodb.Table(self.table_name)
@@ -84,7 +84,7 @@ class AlEnv:
                 if e.response['Error']['Code'] == 'ResourceNotFoundException':
                     raise AlEnvConfigurationTableUnavailableException(self.table_name)
                 else:
-                    raise AlEnvException(e)
+                    raise AlEnvException() from e
 
     def get(self, key, default=None, format='decoded', type=None):
         if "dynamodb" not in self.source:
@@ -104,7 +104,7 @@ class AlEnv:
         except self.ssm.exceptions.ParameterNotFound:
             return default
         except botocore.exceptions.ClientError as e:
-            raise AlEnvException(e)
+            raise AlEnvException() from e
         return parameter["Parameter"]["Value"]
 
     def _make_ssm_key(self, option_key):

--- a/almdrlib/environment.py
+++ b/almdrlib/environment.py
@@ -83,7 +83,7 @@ class AlEnv:
                     raise AlEnvException(e)
 
     def get(self, key, default=None, format='decoded', type=None):
-        if self.source == "dynamodb":
+        if self.source != "dynamodb":
             raise AlmdrlibSourceNotEnabledError("dynamodb is not enabled for this environment")
         fetched_value = self.table.get_item(Key={"key": self._make_ddb_key(key)}).get('Item', {}).get('value')
         converted = AlEnv._convert(fetched_value, format, type)
@@ -93,7 +93,7 @@ class AlEnv:
             return default
 
     def get_parameter(self, key, default=None, decrypt=False):
-        if self.source == "ssm":
+        if self.source != "ssm":
             raise AlmdrlibSourceNotEnabledError("ssm is not enabled for this environment")
         try:
             parameter = self.ssm.get_parameter(Name=self._make_ssm_key(key), WithDecryption=decrypt)
@@ -104,10 +104,10 @@ class AlEnv:
         return parameter["Parameter"]["Value"]
 
     def _make_ssm_key(self, option_key):
-        return f"/deployments/{self.stack_name}/{self._get_region()}/env-settings/{self.application_name}/{self._make_client_option_key()}"
+        return f"/deployments/{self.stack_name}/{self._get_region()}/env-settings/{self.application_name}/{self._make_client_option_key(option_key)}"
 
     def _make_ddb_key(self, option_key):
-        return f"{self.application_name}.{self._make_client_option_key()}"
+        return f"{self.application_name}.{self._make_client_option_key(option_key)}"
 
     def _make_client_option_key(self, option_key):
         if self.client is None:

--- a/almdrlib/environment.py
+++ b/almdrlib/environment.py
@@ -15,6 +15,8 @@ Network or io errors are not handled.
 Usage:
 # export ALERTLOGIC_STACK_REGION=us-east-1
 # export ALERTLOGIC_STACK_NAME=integration
+
+Dynamodb usage:
 >> env = AlEnv("myapplication")
 # Assuming parameter is stored in ddb as '"value"'
 >> env.get("my_parameter")
@@ -29,6 +31,8 @@ Usage:
 # Assuming parameter is stored in ddb as '"true"'
 >> env.get("my_parameter", type='boolean')
 True
+
+SSM usage:
 >> env = AlEnv("myapplication", source="ssm")
 # For String types in SSM:
 >> env.get_parameter("my_parameter")

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -95,6 +95,10 @@ class TestAlEnv(unittest.TestCase):
         env = AlEnv("otherapplication", "authc", source="ssm")
         assert env.get_parameter("stringparam") == 'testingtesting'
 
+        env = AlEnv("someapplication", source=("ssm", "dynamodb"))
+        assert env.get("strkey") == 'strvalue'
+        assert env.get_parameter("stringparam") == 'testingtesting'
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Made changes to logically separate getting credentials from dynamodb and ssm. In the previous implementation, if dynamodb raised an exception while being setup in AlEnv, ssm wouldn't be checked for keys, and if ssm raised an exception while getting a key dynamodb wouldn't be checked. This was bad because if we have keys in ssm, why would we set up permissions for dynamodb, and vice versa? So, now it is set up to expect keys in **either** ssm or dynamodb, and one failing won't affect checking the other.

Perhaps different classes for each would be better, but this should work for now.

Also, modified the SSM key to check to the form /deployments/STACK/REGION/env-settings/APPLICATION/aims_authc.KEY; this is better in line with the key format used in other services, and also by using the hierarchical APPLICATION/ we should be able to set up a single IAM permission in the CF template to give access to both the access key and the secret.